### PR TITLE
将依赖的 anima-template 更新到最新版本

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,7 +9,7 @@ module.exports = function() {
     if (file.isNull()) return cb(null, file); // pass along
 
     var str = file.contents.toString('utf-8');
-    file.contents = new Buffer(atpl(str));
+    file.contents = new Buffer(atpl(str).render.toString());
     file.path = file.path + '.js';
     cb(null, file);
   });

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Gulp plugin for anima-template.",
   "main": "index",
   "dependencies": {
-    "anima-template": "~1.0.12",
+    "anima-template": "~1.0.13",
     "through2": "~0.6.3"
   },
   "devDependencies": {


### PR DESCRIPTION
由于 anima-template 最新的 1.0.13 预编译函数输出结果有较大改变，会造成原先使用 ~1.0.12 控制版本的 gulp 脚本执行失败
